### PR TITLE
Fix public paths on Windows

### DIFF
--- a/src/codeBuilders.js
+++ b/src/codeBuilders.js
@@ -33,7 +33,7 @@ exports.buildMethodCode = function(methodName, defaultPublicPath) {
     `  return ${methodName}();`,
     "} catch (e) {",
     "  console.error(e);",
-    `  return "${defaultPublicPath}";`,
+    `  return "${defaultPublicPath.replace(/\\/g, "\\\\")}";`,
     "}"
   ].join("\n");
 };

--- a/test/webpack3/webpack.config.js
+++ b/test/webpack3/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = {
   output: {
     filename: "[name].js",
     chunkFilename: "[name].js",
-    publicPath: "",
+    publicPath: path.resolve("./build"),
     path: path.resolve("./build")
   },
   plugins: [

--- a/test/webpack4/webpack.config.js
+++ b/test/webpack4/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
   output: {
     filename: "[name].js",
     chunkFilename: "[name].js",
-    publicPath: "",
+    publicPath: path.resolve("./build"),
     path: path.resolve("./build")
   },
   plugins: [


### PR DESCRIPTION
This is a very specific issue triggered by a couple of conditions:

The scenario in question is as follows:
I am using `mocha-webpack`, which updates any webpack.config `output.publicPath` property to point to a path resolved with `path` module. Since this module resolves the path accordingly on both Unix and Windows systems, the correct folder slash is used (`\` in Windows, and `/` in Unix). The resolved path is passed directly to the generated code and in Windows generates an issue in which escapes the last character of the path:

`return "C:\path\to\my\module\"`

The fix replaces backslashes to escaped backslashes for path to work on Windows:

`return "C:\\path\\to\\my\\module\\"`

I also included these path updates to tests, to verify in both OSs.

Please let me know if there's any issue, so I can fix it. Thanks!

 