### PR TITLE
use document.createElement + jsonpScriptSrc patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-require-from",
-  "version": "1.5.0",
+  "version": "1.7.0-beta.0",
   "description": "Webpack plugin that allows to configure path or URL for fetching dynamic imports",
   "main": "index.js",
   "scripts": {

--- a/test/common/playground.js
+++ b/test/common/playground.js
@@ -1,0 +1,36 @@
+const memoryFS = require("memory-fs");
+const cloneDeep = require("lodash.clonedeep");
+
+const webpackConfigurations = require("./webpack.config.shared");
+
+const compile = (webpackEngine, config, fs) => {
+  const compiler = webpackEngine(cloneDeep(config));
+  compiler.outputFileSystem = fs;
+  return new Promise((resolve, reject) => {
+    compiler.run((err, stats) => {
+      if (err || stats.hasErrors()) {
+        reject(new Error(err || stats.compilation.errors));
+      }
+      const code = fs
+        .readFileSync(`${webpackConfigurations.buildPath}/main.js`)
+        .toString();
+      console.log(code);
+      // eval(code);
+      resolve();
+    });
+  });
+};
+
+const compileWithWebpackVersion = (webpackVersion, configName) =>
+  compile(
+    require(`../${webpackVersion}/node_modules/webpack`),
+    webpackConfigurations[webpackVersion][configName],
+    new memoryFS()
+  );
+
+(async function run() {
+  await compileWithWebpackVersion(
+    "webpack2",
+    "replaceSrcMethodName_pluginConf"
+  );
+})();


### PR DESCRIPTION
Depending on webpack version we will create a different "patch".

For webpack 4+, monkey-patch the  extracted `jsonpScriptSrc` method from https://github.com/webpack/webpack/blob/master/lib/web/JsonpMainTemplatePlugin.js#L125

For older versions on webpack, wrap the output of https://github.com/webpack/webpack/blob/webpack-3/lib/JsonpMainTemplatePlugin.js#L50 hook into a function that overrides the global `document.createElement` method. That allows to capture the original params of `<script>` tag created by webpack, modify and re-assign arguments.

Resolved https://github.com/agoldis/webpack-require-from/issues/14
