### PR TITLE
Add feature to disable plugin for css files

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ If used together with `methodName` or `variableName`, chunks URL will be first m
 
 The plugin will invoke `console.error` when the method name you defined in `replaceSrcMethodName`, `methodName` or `variableName` cannot be detected. Turning this option on will suppress the error messages.
 
+## `disableCss (default: false)`
+
+Disable plugin for css files. Tthis option is useful if your project includes mini-css-extract-plugin or extract-css-chunks-webpack-plugin. These plugins provide their own way of setting public path.
+
 ## Defining gobaly available methods and variable
 
 When your JS code is executed in browser, the variable/methods whose names you mention as `variableName`, `methodName` or `replaceSrcMethodName` value, should be set **before** the first call to `require.ensure()` or `import()` is executed.

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,3 +1,4 @@
 exports.PLUGIN_NAME = "WebpackRequireFrom";
 exports.REPLACE_SRC_OPTION_NAME = "replaceSrcMethodName"
 exports.SUPPRESS_ERRORS_OPTION_NAME = "suppressErrors"
+exports.DISABLE_CSS_OPTION_NAME = "disableCss";

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,7 +1,8 @@
 const {
   PLUGIN_NAME,
   REPLACE_SRC_OPTION_NAME,
-  SUPPRESS_ERRORS_OPTION_NAME
+  SUPPRESS_ERRORS_OPTION_NAME,
+  DISABLE_CSS_OPTION_NAME,
 } = require("./constants");
 const { getHook, isLegacyTapable } = require("./helpers");
 
@@ -45,7 +46,13 @@ class WebpackRequireFrom {
   }
 
   compilationHook(compilation) {
-    const { mainTemplate } = compilation;
+    const { mainTemplate, name } = compilation;
+
+    if(this.options[DISABLE_CSS_OPTION_NAME]) {
+      // skip further execution for CSS compilation
+      if(/\.(sa|sc|c)ss$/i.test(name))
+        return;
+    }
 
     // compilation.hooks.addEntry.tap(PLUGIN_NAME, (entry, name) => {
     //   console.log("this", this);
@@ -166,6 +173,8 @@ class WebpackRequireFrom {
   }
 }
 
-WebpackRequireFrom.prototype.defaultOptions = {};
+WebpackRequireFrom.prototype.defaultOptions = {
+    [DISABLE_CSS_OPTION_NAME]: false,
+};
 
 module.exports = WebpackRequireFrom;


### PR DESCRIPTION
Fixes #9 

Whenever `webpack-require-from` plugin is used with `mini-css-extract-plugin`, it logs errors in console as shown below:

![image](https://user-images.githubusercontent.com/3319815/74088185-5db88380-4ab9-11ea-869d-98aed4303a22.png)

To my surprise, webpack compilation completes successfully. 


On further inspection I found that `mini-css-extract-plugin` does not honors public path overridded by `webpack-require-from` plugin. `mini-css-extract-plugin` has is own options to set public path for CSS files.

`webpack-require-from` will log warnings for each import or url CSS rules. So sometimes it becomes really painful to browse through the compilation logs. One way to solve this is to set `suppressErrors`
 to true. But this will suppress all errors in production as well for JS public path. 

So I propose the option `disableCss` to avoid compilation of CSS files by `mini-css-extract-plugin` with extensions .css, .scss, .sass . For backward compatibility disableCss will be false by default.  
Developers can set public paths for CSS files using configurations provided by `mini-css-extract-plugin`.

One can have exact same experience with `extract-css-chunks-webpack-plugin` as well.

I have created git repository to test and reproduce this issue, https://github.com/ppiyush13/webpack-require-from-example/blob/master/readme.md
